### PR TITLE
fix: add hard-coded `ref` instead of checking out default branch

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,6 +44,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: lazerwalker/electron-wrapper-template
+          ref: 5c042ff4653f58df3f7d0e37e765188c298bd11d
           path: app
 
       - name: Set up Electron app environment


### PR DESCRIPTION
Currently the checkout step will always use the latest version of the default branch of the template repo, which may or may not be compatible with older versions of the builder repo. In the future, you may end up making updates to the template that involve breaking changes for the builder, and although you can push a matching change to the builder right away, everyone else's workflows will break without warning (it's unlikely folks will be pulling upstream changes frequently, if at all).

Note: It may be worth looking into making the template either part of this repo, a self-contained action, or an executable npm module rather than manually checking it out as part of this project's workflow so that the versioning/dependency management is less of a concern.