### PR TITLE
fix: author metadata

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -83,6 +83,16 @@ jobs:
           fileName: "win-certificate.pfx"
           encodedString: ${{ secrets.CERTIFICATE_WINDOWS_PFX }}
 
+      - name: Set author
+        run: |
+          node -e "\
+          const fs = require('fs');\
+          const pkg=require('./app/package.json');\
+          pkg.author=process.env.AUTHOR;\
+          fs.writeFileSync('./app/package.json',JSON.stringify(pkg,undefined,'\t'));"
+        env:
+          AUTHOR: ${{ github.repository_owner }}
+
       - name: Build the app
         working-directory: ./app
         env:

--- a/README.md
+++ b/README.md
@@ -25,11 +25,12 @@ More detailed instructions follow, but here's the big-picture of what you'll be 
 
 1. While logged in to GitHub and viewing this project, click the green "Use this Template" button at the top of the page.
 2. Move your game files into your new git repository. Put anything you'll need into the `src` folder. This must include an `index.html` file, which will be loaded in a custom web browser whenever players open your game, but might also include other resources like images or audio. If you have files like images, audio, or external JavaScript, it's better to include them directly in this folder instead of linking to external URLs so your game will work offline.
-3. In your new repo, there will be a file in the `.github/workflows` subfolder called `main.yml`. Down on [line 89](https://github.com/lazerwalker/twine-app-builder/blob/main/.github/workflows/main.yml#L89), in the "Build the app" section, change the `APP_NAME` variable from "My Twine Game" to whatever you want your app to be called.
-4. If you have a custom app icon you'd like to use, put that as `icon.png` in the root of the repo. It will be automatically resized as long as it is square and at least 1024x1024.
-5. Commit and push these changes to GitHub
-6. Wait a few minutes! You can go to the "Actions" tab in your GitHub repo to see build progress. If you don't see any progress in the Actions tab, you may need to enable Actions for your repo in the repository settings.
-7. When the build is done, the "Releases" section of your repo will contain download links. You can find that by clicking the "Releases" section on the right-hand side of your main repo page, or going directly to https://github.com/YOUR_USERNAME/YOUR_REPO/releases.
+3. In your new repo, there will be a file in the `.github/workflows` subfolder called `main.yml`. Down on [line 99](https://github.com/lazerwalker/twine-app-builder/blob/main/.github/workflows/main.yml#L99), in the "Build the app" section, change the `APP_NAME` variable from "My Twine Game" to whatever you want your app to be called.
+4. In the same file on [line 94](https://github.com/lazerwalker/twine-app-builder/blob/main/.github/workflows/main.yml#L94), in the "Set author" section, change the `AUTHOR` variable to the name you want associated as the publisher/copyright holder for the app (if you don't change this, it will use the username of the repository owner).
+5. If you have a custom app icon you'd like to use, put that as `icon.png` in the root of the repo. It will be automatically resized as long as it is square and at least 1024x1024.
+6. Commit and push these changes to GitHub
+7. Wait a few minutes! You can go to the "Actions" tab in your GitHub repo to see build progress. If you don't see any progress in the Actions tab, you may need to enable Actions for your repo in the repository settings.
+8. When the build is done, the "Releases" section of your repo will contain download links. You can find that by clicking the "Releases" section on the right-hand side of your main repo page, or going directly to https://github.com/YOUR_USERNAME/YOUR_REPO/releases.
 
 As you make changes to your game, repeat the last few steps. Every new git commit that you make and push up to GitHub will result in a new build of your game.
 


### PR DESCRIPTION
Electron and the distribution projects infer a bunch of info from `package.json` when generating application metadata. Because of this, the `author` field ends up populating some user-facing fields, including copyright info, resulting in apps being listed as "Copyright 2021 Em Lazer-Walker".

Modifying it directly from the workflow feels kinda hacky, but it seems to be the simplest way to override it in this setup (the forge config does have `packagerConfig.appCopyright` and `packagerConfig.win32metadata.CompanyName` options, but these aren't comprehensive and I'm not sure where else the `author` value is used as a default).